### PR TITLE
change call(textLib.. to call_ext(textLib.. to reconcile breaking change in BYOND Build 515.1590. 

### DIFF
--- a/code/lib/rng/gen.dm
+++ b/code/lib/rng/gen.dm
@@ -14,7 +14,7 @@ proc
 					turf/t = locate(XX,YY,zlevel)
 
 				if(t){
-					buffer += call(textLib,"ByondColors")(t.display)
+					buffer += call_ext(textLib,"ByondColors")(t.display)
 				}
 
 				if(XX >= world.maxx){ buffer += "<br />"; }

--- a/code/procs/rColor.dm
+++ b/code/procs/rColor.dm
@@ -1,15 +1,15 @@
 proc
 	rColor(text, color, client){
 
-		if(!color){ return call(textLib,"StripColors")(text); }
+		if(!color){ return call_ext(textLib,"StripColors")(text); }
 
 		switch(client){
 			if(TELNET){
-				return call(textLib,"ParseColors")(text);
+				return call_ext(textLib,"ParseColors")(text);
 			}
 
 			if(BYOND){
-				return call(textLib,"ByondColors")(text);
+				return call_ext(textLib,"ByondColors")(text);
 			}
 		}
 

--- a/code/procs/rStrip_Escapes.dm
+++ b/code/procs/rStrip_Escapes.dm
@@ -1,4 +1,4 @@
 proc
 	rStrip_Escapes(text){
-		return call(textLib,"StripColors")(text)
+		return call_ext(textLib,"StripColors")(text)
 	}

--- a/code/procs/time.dm
+++ b/code/procs/time.dm
@@ -8,4 +8,4 @@ proc
 		return "[h]h [m]m [s]s"
 	}
 
-	systemTime() return call(textLib,"systemTime")()
+	systemTime() return call_ext(textLib,"systemTime")()

--- a/index/rColor.dm
+++ b/index/rColor.dm
@@ -1,4 +1,4 @@
 proc
 	rColor(text){
-		return call(textLib,"ByondColors")(text)
+		return call_ext(textLib,"ByondColors")(text)
 	}


### PR DESCRIPTION
This PR closes #1 

I did some investigating and discovered that my little `call_ext` change from the issue was right, but I hadn't gone far enough into other files to see it was used elsewhere. The log revealed more of the same errors I saw in the issue but for other files. These were suppressed for whatever reason in the running terminal.

In the [BYOND changelogs](https://www.byond.com/docs/notes/515.html) for 515, I found the related line:

> call_ext() is now used for all external library calls, in place of call(), to clarify the difference between calling DM code and calling external code. This is a breaking change for some games, although it won't have any impact on games compiled prior to BYOND 515. Trying to call() an external library will either produce a compiler warning if the library name is a constant string, or a runtime error otherwise.

This was indeed a breaking change for DBZFE of the runtime variety. Now, the game properly boots and seems to work as expected. There certainly may be other issues related to BYOND 515, but this is a big solve to get the game running.

One question I don't know the answer to: will this break the game if it's run on BYOND < 515.... ? I didn't test that and have a finicky linux setup that I don't want to tamper with.

Hope this helps!